### PR TITLE
Issue Inversify/730

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ The `inversify-inject-decorators` type definitions are included in the npm modul
 
 Please refer to the [InversifyJS documentation](https://github.com/inversify/InversifyJS#installation) to learn more about the installation process.
 
+## Caching vs Non Caching Behaviour
+
+By default, the lazy injection mechanism implemented by this will cache all requests to the underlying container.
+This means that rebinding or unbinding services to/from service identifiers will not be reflected in the instances into which these services have been injected into. The same holds true for scenarios where you dynamically load/unload container modules and thus either add or remove bindings from your container.
+
+To overcome this limitation, one can now pass an additional boolean parameter to `getDecorators(container: Container, doCache = true)`. When set to `false`, services resolved from the container will no longer be cached and will always be resolved from the container directly, e.g.
+
+```ts
+import { Container } from "inversify";
+import getDecorators from "inversify-inject-decorators";
+
+const container: Container = new Container();
+const { lazyInject } = getDecorators(container, false);
+```
+
 ## Basic property lazy-injection with `@lazyInject`
 The following example showcases how to inject into a property 
 using the `@lazyInject` decorator:

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -5,13 +5,18 @@ const INJECTION = Symbol.for("INJECTION");
 function _proxyGetter(
     proto: any,
     key: string,
-    resolve: () => any
+    resolve: () => any,
+    doCache: boolean
 ) {
     function getter() {
-        if (!Reflect.hasMetadata(INJECTION, this, key)) {
+        if (doCache && !Reflect.hasMetadata(INJECTION, this, key)) {
             Reflect.defineMetadata(INJECTION, resolve(), this, key);
         }
-        return Reflect.getMetadata(INJECTION, this, key);
+        if (Reflect.hasMetadata(INJECTION, this, key)) {
+            return Reflect.getMetadata(INJECTION, this, key);
+        } else {
+            return resolve();
+        }
     }
 
     function setter(newVal: any) {
@@ -26,7 +31,7 @@ function _proxyGetter(
     });
 }
 
-function makePropertyInjectDecorator(container: interfaces.Container) {
+function makePropertyInjectDecorator(container: interfaces.Container, doCache: boolean) {
     return function(serviceIdentifier: interfaces.ServiceIdentifier<any>) {
         return function(proto: any, key: string): void {
 
@@ -34,13 +39,13 @@ function makePropertyInjectDecorator(container: interfaces.Container) {
                 return container.get(serviceIdentifier);
             };
 
-            _proxyGetter(proto, key, resolve);
+            _proxyGetter(proto, key, resolve, doCache);
 
         };
     };
 }
 
-function makePropertyInjectNamedDecorator(container: interfaces.Container) {
+function makePropertyInjectNamedDecorator(container: interfaces.Container, doCache: boolean) {
     return function(serviceIdentifier: interfaces.ServiceIdentifier<any>, named: string) {
         return function(proto: any, key: string): void {
 
@@ -48,13 +53,13 @@ function makePropertyInjectNamedDecorator(container: interfaces.Container) {
                 return container.getNamed(serviceIdentifier, named);
             };
 
-            _proxyGetter(proto, key, resolve);
+            _proxyGetter(proto, key, resolve, doCache);
 
         };
     };
 }
 
-function makePropertyInjectTaggedDecorator(container: interfaces.Container) {
+function makePropertyInjectTaggedDecorator(container: interfaces.Container, doCache: boolean) {
     return function(serviceIdentifier: interfaces.ServiceIdentifier<any>, key: string, value: any) {
         return function(proto: any, propertyName: string): void {
 
@@ -62,13 +67,13 @@ function makePropertyInjectTaggedDecorator(container: interfaces.Container) {
                 return container.getTagged(serviceIdentifier, key, value);
             };
 
-            _proxyGetter(proto, propertyName , resolve);
+            _proxyGetter(proto, propertyName , resolve, doCache);
 
         };
     };
 }
 
-function makePropertyMultiInjectDecorator(container: interfaces.Container) {
+function makePropertyMultiInjectDecorator(container: interfaces.Container, doCache: boolean) {
     return function(serviceIdentifier: interfaces.ServiceIdentifier<any>) {
         return function(proto: any, key: string): void {
 
@@ -76,7 +81,7 @@ function makePropertyMultiInjectDecorator(container: interfaces.Container) {
                 return container.getAll(serviceIdentifier);
             };
 
-            _proxyGetter(proto, key, resolve);
+            _proxyGetter(proto, key, resolve, doCache);
 
         };
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,12 @@ import {
 } from "./decorators";
 
 
-function getDecorators(container: interfaces.Container) {
+function getDecorators(container: interfaces.Container, doCache = true) {
 
-    let lazyInject = makePropertyInjectDecorator(container);
-    let lazyInjectNamed = makePropertyInjectNamedDecorator(container);
-    let lazyInjectTagged = makePropertyInjectTaggedDecorator(container);
-    let lazyMultiInject = makePropertyMultiInjectDecorator(container);
+    let lazyInject = makePropertyInjectDecorator(container, doCache);
+    let lazyInjectNamed = makePropertyInjectNamedDecorator(container, doCache);
+    let lazyInjectTagged = makePropertyInjectTaggedDecorator(container, doCache);
+    let lazyMultiInject = makePropertyMultiInjectDecorator(container, doCache);
 
     return {
        lazyInject ,

--- a/test/issue-730.test.ts
+++ b/test/issue-730.test.ts
@@ -1,0 +1,186 @@
+import { expect } from "chai";
+import getDecorators from "../src/index";
+import { interfaces, Container, ContainerModule, injectable, named, tagged } from "inversify";
+
+describe("Issue inversify/InversifyJS/issues/730 - with doCache set to false", () => {
+
+    describe("when binding/unbinding", () => {
+
+        it("Should resolve from container directly", () => {
+
+            const container = new Container();
+            const {
+                lazyInject,
+                lazyInjectNamed,
+                lazyInjectTagged,
+                lazyMultiInject
+            } = getDecorators(container, false);
+
+            const FOO = "FOO";
+            const BAR = "BAR";
+
+            @injectable()
+            class Foo {
+            }
+
+            @injectable()
+            class NamedFoo {
+            }
+
+            @injectable()
+            class TaggedFoo {
+            }
+
+            container.bind<Foo>(FOO).to(Foo);
+            container.bind<NamedFoo>(BAR).to(NamedFoo).whenTargetNamed("bar");
+            container.bind<TaggedFoo>(BAR).to(TaggedFoo).whenTargetTagged("bar", true);
+
+            @injectable()
+            class Test {
+                @lazyInject(FOO) public foo: Foo;
+                @lazyMultiInject(FOO) public foos: Foo[];
+                @lazyInjectNamed(BAR, "bar") @named("bar") public namedFoo: Foo;
+                @lazyInjectTagged(BAR, "bar", true) @tagged("bar", true) public taggedFoo: Foo;
+            }
+
+            const sut: any = new Test();
+
+            function actual(key: string): any {
+              return sut[key];
+            }
+
+            expect(actual("foo")).to.be.instanceof(Foo);
+            expect(actual("foos")[0]).to.be.instanceof(Foo);
+            expect(actual("namedFoo")).to.be.instanceof(NamedFoo);
+            expect(actual("taggedFoo")).to.be.instanceof(TaggedFoo);
+
+            function throws(key: string): () => any {
+                return () => {
+                  return sut[key];
+                };
+            }
+
+            container.unbind(FOO);
+            container.unbind(BAR);
+
+            expect(throws("foo")).to.throw(
+                "No matching bindings found for serviceIdentifier: FOO"
+            );
+            expect(throws("foos")).to.throw(
+                "No matching bindings found for serviceIdentifier: FOO"
+            );
+            expect(throws("namedFoo")).to.throw(
+                "No matching bindings found for serviceIdentifier: BAR"
+            );
+            expect(throws("taggedFoo")).to.throw(
+                "No matching bindings found for serviceIdentifier: BAR"
+            );
+        });
+
+    });
+
+    describe("when loading/unloading container modules", () => {
+
+        it("Should resolve from container directly", () => {
+
+            const container = new Container();
+            const {
+                lazyInject,
+                lazyInjectNamed,
+                lazyInjectTagged,
+                lazyMultiInject
+            } = getDecorators(container, false);
+
+            const SINGLETON_FOO = "SINGLETON_FOO";
+            const FOO = "FOO";
+            const BAR = "BAR";
+
+            @injectable()
+            class FooBarBase {
+            }
+
+            @injectable()
+            class SingletonFoo extends FooBarBase {
+            }
+
+            @injectable()
+            class Foo extends FooBarBase {
+            }
+
+            @injectable()
+            class Bar extends FooBarBase {
+            }
+
+            @injectable()
+            class NamedBar extends FooBarBase {
+            }
+
+            @injectable()
+            class TaggedBar extends FooBarBase {
+            }
+
+            const mFoo = new ContainerModule((bind: interfaces.Bind) => {
+                bind<FooBarBase>(SINGLETON_FOO).to(SingletonFoo);
+                bind<FooBarBase>(FOO).to(Foo);
+            });
+            const mBar = new ContainerModule((bind: interfaces.Bind) => {
+                bind<FooBarBase>(FOO).to(Bar);
+                bind<FooBarBase>(BAR).to(NamedBar).whenTargetNamed("bar");
+                bind<FooBarBase>(BAR).to(TaggedBar).whenTargetTagged("bar", true);
+            });
+
+            container.load(mFoo, mBar);
+
+            @injectable()
+            class Test {
+                @lazyInject(SINGLETON_FOO) public singletonFoo: FooBarBase;
+                @lazyMultiInject(FOO) public foos: FooBarBase[];
+                @lazyInjectNamed(BAR, "bar") @named("bar") public namedFoo: FooBarBase;
+                @lazyInjectTagged(BAR, "bar", true) @tagged("bar", true) public taggedFoo: FooBarBase;
+            }
+
+            const sut: any = new Test();
+
+            function actual(key: string): any {
+              return sut[key];
+            }
+
+            expect(actual("singletonFoo")).to.be.instanceof(SingletonFoo);
+            let foos: FooBarBase[] = actual("foos");
+            expect(foos.length).to.equal(2);
+            expect(foos[0]).to.be.instanceof(Foo);
+            expect(foos[1]).to.be.instanceof(Bar);
+
+            container.unload(mBar);
+
+            expect(actual("singletonFoo")).to.be.instanceof(SingletonFoo);
+            foos = actual("foos");
+            expect(foos.length).to.equal(1);
+            expect(foos[0]).to.be.instanceof(Foo);
+
+            function throws(key: string): () => any {
+                return () => {
+                  return sut[key];
+                };
+            }
+
+            expect(throws("namedFoo")).to.throw(
+                "No matching bindings found for serviceIdentifier: BAR"
+            );
+            expect(throws("taggedFoo")).to.throw(
+                "No matching bindings found for serviceIdentifier: BAR"
+            );
+
+            container.unload(mFoo);
+
+            expect(throws("singletonFoo")).to.throw(
+                "No matching bindings found for serviceIdentifier: SINGLETON_FOO"
+            );
+            expect(throws("foos")).to.throw(
+                "No matching bindings found for serviceIdentifier: FOO"
+            );
+        });
+
+    });
+
+});


### PR DESCRIPTION
# PR Details

## Description

This adds a doCache option, defaults to true, to getDecorators(). In turn this will enable caching of the resolved values from the container or disable it. The latter enables the user to dynamically bind/unbind, load/unload container modules and have these changes reflected in existing instances, where values have already been lazily injected. 

## Related Issue

https://github.com/inversify/InversifyJS/issues/730

## Motivation and Context

Dynamically binding/unbinding, loading/unloading of container modules does not play well with lazy injection decorators without this fix.

## How Has This Been Tested

Tests have been implemented in test/issue-730.test.ts

- [x] lazyInject
- [x] lazyMultiInject
- [x] lazyInjectNamed
- [x] lazyInjectTagged

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  