### PR TITLE
named and tagged key support number and symbol type

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -46,7 +46,7 @@ function makePropertyInjectDecorator(container: interfaces.Container, doCache: b
 }
 
 function makePropertyInjectNamedDecorator(container: interfaces.Container, doCache: boolean) {
-    return function(serviceIdentifier: interfaces.ServiceIdentifier<any>, named: string) {
+    return function(serviceIdentifier: interfaces.ServiceIdentifier<any>, named: string | number | symbol) {
         return function(proto: any, key: string): void {
 
             let resolve = () => {
@@ -60,7 +60,7 @@ function makePropertyInjectNamedDecorator(container: interfaces.Container, doCac
 }
 
 function makePropertyInjectTaggedDecorator(container: interfaces.Container, doCache: boolean) {
-    return function(serviceIdentifier: interfaces.ServiceIdentifier<any>, key: string, value: any) {
+    return function(serviceIdentifier: interfaces.ServiceIdentifier<any>, key: string | number | symbol, value: any) {
         return function(proto: any, propertyName: string): void {
 
             let resolve = () => {


### PR DESCRIPTION
# PR Details

In `inversifyJS 5.0.1`, binding and injecting by `tag` or `named` support `number` and `symbol` type.
This repository not supports it :(

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.