### PR TITLE
add desc field sent by cocos creator

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -6,7 +6,8 @@ function _proxyGetter(
     proto: any,
     key: string,
     resolve: () => any,
-    doCache: boolean
+    doCache: boolean,
+    desc : any
 ) {
     function getter() {
         if (doCache && !Reflect.hasMetadata(INJECTION, this, key)) {
@@ -23,23 +24,25 @@ function _proxyGetter(
         Reflect.defineMetadata(INJECTION, newVal, this, key);
     }
 
-    Object.defineProperty(proto, key, {
+    Object.assign(desc,{
         configurable: true,
         enumerable: true,
         get: getter,
         set: setter
     });
+
+    Object.defineProperty(proto, key, desc``);
 }
 
 function makePropertyInjectDecorator(container: interfaces.Container, doCache: boolean) {
     return function(serviceIdentifier: interfaces.ServiceIdentifier<any>) {
-        return function(proto: any, key: string): void {
+        return function(proto: any, key: string, desc: any): void {
 
             let resolve = () => {
                 return container.get(serviceIdentifier);
             };
 
-            _proxyGetter(proto, key, resolve, doCache);
+            _proxyGetter(proto, key, resolve, doCache,desc);
 
         };
     };
@@ -47,13 +50,13 @@ function makePropertyInjectDecorator(container: interfaces.Container, doCache: b
 
 function makePropertyInjectNamedDecorator(container: interfaces.Container, doCache: boolean) {
     return function(serviceIdentifier: interfaces.ServiceIdentifier<any>, named: string) {
-        return function(proto: any, key: string): void {
+        return function(proto: any, key: string,desc:any): void {
 
             let resolve = () => {
                 return container.getNamed(serviceIdentifier, named);
             };
 
-            _proxyGetter(proto, key, resolve, doCache);
+            _proxyGetter(proto, key, resolve, doCache,desc);
 
         };
     };
@@ -61,13 +64,13 @@ function makePropertyInjectNamedDecorator(container: interfaces.Container, doCac
 
 function makePropertyInjectTaggedDecorator(container: interfaces.Container, doCache: boolean) {
     return function(serviceIdentifier: interfaces.ServiceIdentifier<any>, key: string, value: any) {
-        return function(proto: any, propertyName: string): void {
+        return function(proto: any, propertyName: string,desc:any): void {
 
             let resolve = () => {
                 return container.getTagged(serviceIdentifier, key, value);
             };
 
-            _proxyGetter(proto, propertyName , resolve, doCache);
+            _proxyGetter(proto, propertyName , resolve, doCache,desc);
 
         };
     };
@@ -75,13 +78,13 @@ function makePropertyInjectTaggedDecorator(container: interfaces.Container, doCa
 
 function makePropertyMultiInjectDecorator(container: interfaces.Container, doCache: boolean) {
     return function(serviceIdentifier: interfaces.ServiceIdentifier<any>) {
-        return function(proto: any, key: string): void {
+        return function(proto: any, key: string, desc:any): void {
 
             let resolve = () => {
                 return container.getAll(serviceIdentifier);
             };
 
-            _proxyGetter(proto, key, resolve, doCache);
+            _proxyGetter(proto, key, resolve, doCache,desc);
 
         };
     };


### PR DESCRIPTION
# PR Details

This  modification is made for work to allow cocos creator can inject dependencies into cc.Components.

## Description

It add new field to __proxyGetter function with description of component property made by cocos-creator component instantiator.

## Related Issue

## Motivation and Context

This solve de problem of injecting properties into cocos creator Components 

## How Has This Been Tested


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.